### PR TITLE
Возврат к использованию библиотеке ElasticSearch, а не ElasticSearch7…

### DIFF
--- a/mpsiemlib/modules/Events.py
+++ b/mpsiemlib/modules/Events.py
@@ -3,8 +3,8 @@ import pytz
 from typing import Iterator
 from datetime import datetime, timedelta
 
-from elasticsearch7 import Elasticsearch, helpers
-from elasticsearch7.exceptions import NotFoundError
+from elasticsearch import Elasticsearch, helpers
+from elasticsearch.exceptions import NotFoundError
 
 from mpsiemlib.common import ModuleInterface, MPSIEMAuth, LoggingHandler, Settings, StorageVersion
 from mpsiemlib.common import get_metrics_start_time, get_metrics_took_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@ certifi==2022.12.7
 chardet==5.1.0
 idna==3.4
 python-dateutil==2.8.2
-pytz==2022.7.1
+pytz==2023.3
 PyYAML==6.0
 requests==2.28.2
 six==1.16.0
-urllib3==1.26.14
+urllib3==1.26.15
 setuptools>=50.3.2
-elasticsearch7>=7.17.8
-wheel==0.38.4
+# Elasticsearch 7.x
+elasticsearch>=7.0.0,<8.0.0
+wheel==0.40.0


### PR DESCRIPTION
Возврат к использованию библиотеке ElasticSearch, а не ElasticSearch7 из-за проблем портирования библиотеки в Positive Technologies